### PR TITLE
feat: Add support for windows

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,5 @@ insecure_skip_verify: false
 
 package_type: "{{ 'rpm' if ansible_os_family in ['RedHat', 'Suse'] else 'deb' }}"
 arch: "{{ 'arm64' if ansible_architecture in ['arm64', 'aarch64'] else 'amd64' }}"
-package_url: "https://github.com/observIQ/observiq-otel-collector/releases/download/v{{ version }}/observiq-otel-collector_v{{ version }}_linux_{{ arch }}.{{ package_type }}"
+linux_package_url: "https://github.com/observIQ/observiq-otel-collector/releases/download/v{{ version }}/observiq-otel-collector_v{{ version }}_linux_{{ arch }}.{{ package_type }}"
+windows_package_url: "https://github.com/observIQ/observiq-otel-collector/releases/download/v{{ version }}/observiq-otel-collector.msi"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,5 +8,5 @@ insecure_skip_verify: false
 
 package_type: "{{ 'rpm' if ansible_os_family in ['RedHat', 'Suse'] else 'deb' }}"
 arch: "{{ 'arm64' if ansible_architecture in ['arm64', 'aarch64'] else 'amd64' }}"
-linux_package_url: "https://github.com/observIQ/observiq-otel-collector/releases/download/v{{ version }}/observiq-otel-collector_v{{ version }}_linux_{{ arch }}.{{ package_type }}"
-windows_package_url: "https://github.com/observIQ/observiq-otel-collector/releases/download/v{{ version }}/observiq-otel-collector.msi"
+linux_package_url: "https://github.com/observIQ/bindplane-agent/releases/download/v{{ version }}/observiq-otel-collector_v{{ version }}_linux_{{ arch }}.{{ package_type }}"
+windows_package_url: "https://github.com/observIQ/bindplane-agent/releases/download/v{{ version }}/observiq-otel-collector.msi"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -44,6 +44,19 @@ Your directory stucture should look like this:
 └── site.yml
 ```
 
+**Windows**
+
+Windows targets must have `winrm` properly configured. See the
+[Ansible Documentation](https://docs.ansible.com/ansible/latest/os_guide/windows_setup.html)
+for proper configuration.
+
+To get started quickly for testing purposes only, you can run the following commands
+to configure winrm quickly, but in an insecure way:
+```ps
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+```
+
 ## Basic Example
 
 This example assumes you have a BindPlane OP instance at the endpoint

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,8 @@
     state: restarted
     daemon_reload: true
     enabled: yes
+
+- name: "restart windows service"
+  win_service:
+    name: "observIQ Distro for OpenTelemetry Collector"
+    state: restarted

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install RHEL package
   yum:
-    name: "{{ package_url }}"
+    name: "{{ linux_package_url }}"
     state: present
     disable_gpg_check: true
   when: 
@@ -10,7 +10,7 @@
 
 - name: Install SUSE package
   zypper:
-    name: "{{ package_url }}"
+    name: "{{ linux_package_url }}"
     state: present
     disable_gpg_check: true
   when: 
@@ -19,7 +19,7 @@
 
 - name: Install Debian package
   apt:
-    deb: "{{ package_url }}"
+    deb: "{{ linux_package_url }}"
     state: present
   when: 
   - ansible_os_family == 'Debian'

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -27,7 +27,7 @@
 
 - name: Check if manager configuration exists
   stat:
-    path: "{{ manager_path }}"
+    path: "{{ linux_manager_path }}"
   register: manager
 
 # Deploy initial manager configuration if it does not exist. BindPlane
@@ -37,7 +37,7 @@
   when: manager.stat.exists == False
   template:
     src: "manager.yaml.tmpl"
-    dest: "{{ manager_path }}"
+    dest: "{{ linux_manager_path }}"
     owner: observiq-otel-collector
     group: observiq-otel-collector
     mode: 0640

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,7 @@
 - name: Call Linux specific playbook
   include_tasks: linux.yml
   when: ansible_os_family in ['Debian', 'RedHat', 'Suse']
+
+- name: Call Windows specific playbook
+  include_tasks: windows.yml
+  when: ansible_os_family in ['Windows']

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install MSI package
   ansible.windows.win_package:
-    # TODO(jsirianni): Use package_url var
     path: "{{ windows_package_url }}"
     product_id: D67CCA1A-6708-4096-8BDE-5069739FB861
     # Install without opamp. OpAMP will be configured when the manager

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,0 +1,29 @@
+---
+- name: Install MSI package
+  ansible.windows.win_package:
+    # TODO(jsirianni): Use package_url var
+    path: "{{ windows_package_url }}"
+    product_id: D67CCA1A-6708-4096-8BDE-5069739FB861
+    # Install without opamp. OpAMP will be configured when the manager
+    # configuration is deployed.
+    arguments:
+      - /quiet 
+      - ENABLEMANAGEMENT=0
+    wait_for_children: true
+    state: present
+
+- name: Check if manager configuration exists
+  win_stat:
+    path: "{{ windows_manager_path }}"
+  register: manager
+
+# Deploy initial manager configuration if it does not exist. BindPlane
+# will push updates to the manager configuration, therefor Ansible
+# cannot maintain it's state.
+- name: Create initial manager configuration
+  when: manager.stat.exists == False
+  template:
+    src: "manager.yaml.tmpl"
+    dest: "{{ windows_manager_path }}"
+    mode: 0640
+  notify: "restart windows service"

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -2,7 +2,6 @@
 - name: Install MSI package
   ansible.windows.win_package:
     path: "{{ windows_package_url }}"
-    product_id: D67CCA1A-6708-4096-8BDE-5069739FB861
     # Install without opamp. OpAMP will be configured when the manager
     # configuration is deployed.
     arguments:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
-manager_path: /opt/observiq-otel-collector/manager.yaml
+linux_manager_path: "/opt/observiq-otel-collector/manager.yaml"
+windows_manager_path: "C:/Program Files/observIQ OpenTelemetry Collector/manager.yaml"


### PR DESCRIPTION
Added support for Windows. Tested to ensure Linux support does not contain regressions.

Tested against BindPlane Cloud with agent version 1.28 and then 1.30 (upgrade in place using ansible). During upgrade, Ansible correctly restarts the service.
```
- name: bindplane-agent
  hosts: all
  #remote_user: joe_sirianni
  #become: yes
  roles:
    - role: bindplane_agent
      version: "1.30.0"
      endpoint: "wss://app.bindplane.com/v1/opamp"
      secret_key: redacted
      labels: configuration=windows
```

Ansible output:
```
PLAY [bindplane-agent] 

TASK [Gathering Facts] 
ok: [34.68.72.42]

TASK [bindplane_agent : Validate version] 
ok: [34.68.72.42] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bindplane_agent : Validate endpoint] 
ok: [34.68.72.42] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bindplane_agent : Validate secret_key] 
ok: [34.68.72.42] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bindplane_agent : Call Linux specific playbook] 
skipping: [34.68.72.42]

TASK [bindplane_agent : Call Windows specific playbook] 
included: /home/jsirianni/git/bindplane-agent-ansible/tasks/windows.yml for 34.68.72.42

TASK [bindplane_agent : Install MSI package] 
changed: [34.68.72.42]

TASK [bindplane_agent : Check if manager configuration exists] 
ok: [34.68.72.42]

TASK [bindplane_agent : Create initial manager configuration] 
changed: [34.68.72.42]

RUNNING HANDLER [bindplane_agent : restart windows service] 
changed: [34.68.72.42]

PLAY RECAP 
34.68.72.42                : ok=9    changed=3    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   

```

BindPlane shows the agent with the correct version and labels.

![Screenshot from 2023-07-28 10-42-55](https://github.com/observIQ/bindplane-agent-ansible/assets/23043836/260998ac-6e55-4351-b541-9d559b9bb8af)

Repeat Ansible runs are idempotent.
```
34.68.72.42                : ok=7    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
```
